### PR TITLE
Update nginx.conf

### DIFF
--- a/jupyterlab/rootfs/etc/nginx/nginx.conf
+++ b/jupyterlab/rootfs/etc/nginx/nginx.conf
@@ -18,6 +18,7 @@ http {
     keepalive_timeout  65;
     lua_shared_dict    auths 16k;
     resolver           %%dns_host%%;
+    client_max_body_size 0;
 
     upstream jupyter {
         ip_hash;


### PR DESCRIPTION
fix uploading larger files than 1 mb leading to
[error] 524#524: *31 client intended to send too large body
according to https://github.com/jupyterlab/jupyterlab/issues/4214

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/